### PR TITLE
Add ability for browser to receiver updates to already discovered services.

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Emitted every time a new service is found that matches the browser.
 
 #### `Event: update`
 
-Emitted every time a update to a service is found that matches the browser.
+Emitted every time an update is received for existing service is found that matches the browser.
 
 #### `Event: down`
 

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ Broadcast the query again.
 
 #### `Event: up`
 
-Emitted when the service is up.
+Emitted when the service is up, and if the txt record of the service is updated `service.updateTxt(object)`.
 
 #### `Event: error`
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,10 @@ Options are the same as given in the `browser.find` function.
 
 Emitted every time a new service is found that matches the browser.
 
+#### `Event: update`
+
+Emitted every time a update to a service is found that matches the browser.
+
 #### `Event: down`
 
 Emitted every time an existing service emmits a goodbye message.

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -82,7 +82,6 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        if (self._serviceMap[service.fqdn]) return // ignore already registered services
         self._addService(service)
       })
     })
@@ -104,9 +103,14 @@ Browser.prototype.update = function () {
 }
 
 Browser.prototype._addService = function (service) {
-  this.services.push(service)
-  this._serviceMap[service.fqdn] = true
-  this.emit('up', service)
+  if (self._serviceMap[service.fqdn]) // ignore already registered services
+  {
+    this.emit('update', service)
+  } else {
+    this.emit('up', service)
+    this.services.push(service)
+    this._serviceMap[service.fqdn] = true
+  }
 }
 
 Browser.prototype._removeService = function (fqdn) {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -82,7 +82,11 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        self._addService(service)
+        if (self._serviceMap[service.fqdn]) 
+          { self._updateService(service) // ignore already registered services
+        } else {
+          self._addService(service)
+        }
       })
     })
   }
@@ -103,14 +107,24 @@ Browser.prototype.update = function () {
 }
 
 Browser.prototype._addService = function (service) {
-  if (this._serviceMap[service.fqdn]) // ignore already registered services
-  {
-    this.emit('update', service)
-  } else {
-    this.emit('up', service)
-    this.services.push(service)
-    this._serviceMap[service.fqdn] = true
-  }
+  this.services.push(service)
+  this._serviceMap[service.fqdn] = true
+  this.emit('up', service)
+}
+
+Browser.prototype._updateService = function (service) {
+  let cachedService, index
+  this.services.some(function (s, i) {
+    if (dnsEqual(s.fqdn, service.fqdn)) {
+      cachedService = s
+      index = i
+      return true
+    }
+    return false
+  })
+  if (!cachedService) return
+  this.services[index] = service;
+  this.emit('update', service)
 }
 
 Browser.prototype._removeService = function (fqdn) {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -82,8 +82,8 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        if (self._serviceMap[service.fqdn]) 
-          { self._updateService(service) // ignore already registered services
+        if (self._serviceMap[service.fqdn]) {
+          self._updateService(service) // ignore already registered services
         } else {
           self._addService(service)
         }
@@ -123,7 +123,7 @@ Browser.prototype._updateService = function (service) {
     return false
   })
   if (!cachedService) return
-  this.services[index] = service;
+  this.services[index] = service
   this.emit('update', service)
 }
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -83,7 +83,7 @@ Browser.prototype.start = function () {
 
       matches.forEach(function (service) {
         if (self._serviceMap[service.fqdn]) {
-          self._updateService(service) // ignore already registered services
+          self._updateService(service)
         } else {
           self._addService(service)
         }

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -103,7 +103,7 @@ Browser.prototype.update = function () {
 }
 
 Browser.prototype._addService = function (service) {
-  if (self._serviceMap[service.fqdn]) // ignore already registered services
+  if (this._serviceMap[service.fqdn]) // ignore already registered services
   {
     this.emit('update', service)
   } else {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -82,8 +82,11 @@ Browser.prototype.start = function () {
       if (matches.length === 0) return
 
       matches.forEach(function (service) {
-        if (self._serviceMap[service.fqdn]) return // ignore already registered services
-        self._addService(service)
+        if (self._serviceMap[service.fqdn]) 
+          { self._updateService(service) // ignore already registered services
+        } else {
+          self._addService(service)
+        }
       })
     })
   }
@@ -107,6 +110,21 @@ Browser.prototype._addService = function (service) {
   this.services.push(service)
   this._serviceMap[service.fqdn] = true
   this.emit('up', service)
+}
+
+Browser.prototype._updateService = function (service) {
+  let cachedService, index
+  this.services.some(function (s, i) {
+    if (dnsEqual(s.fqdn, service.fqdn)) {
+      cachedService = s
+      index = i
+      return true
+    }
+    return false
+  })
+  if (!cachedService) return
+  this.services[index] = service;
+  this.emit('update', service)
 }
 
 Browser.prototype._removeService = function (fqdn) {

--- a/test/bonjour.js
+++ b/test/bonjour.js
@@ -118,34 +118,62 @@ test('bonjour.find', function (bonjour, t) {
   bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'bar' } }).on('up', next())
 })
 
-test('bonjour.change', function (bonjour, t) {
-  const data = { init: true, found: false, timer: null }
-  const service = bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'bar' } }).on('up', function () {
-    const browser = bonjour.find({ type: 'test' })
-    browser.on('up', function (s) {
-      data.browserData = s
-
-      if (data.init) {
-        t.equal(s.txt.foo, 'bar')
-        data.timer = setTimeout(function () {
-          t.equal(s.txt.foo, 'baz')
-          bonjour.destroy()
-          t.end()
-        }, 3000) // Wait for the record to update maximum 3000 ms
-        data.init = false
-        service.updateTxt({ foo: 'baz' })
-      }
-
-      if (!data.init && !data.found && s.txt.foo === 'baz') {
+test('bonjour.change and up event', function (bonjour, t) {
+  const data = { updateTxtSent: false, found: false, timer: null, serviceUp: false }
+  data.timer = setTimeout(function () {
+    t.equal(data.found, true)
+    bonjour.destroy()
+    t.end()
+  }, 3000) // Wait 3000 ms for any additional up messages when the updateTxt is sent
+  const service = bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'originalUp' } }).on('up', function () {
+    if (!data.serviceUp) {  // Workaround for Service.up firing when service.updateTxt is used
+      data.serviceUp = true;
+      const browser = bonjour.find({ type: 'test' })
+      browser.on('up', function (s) {
+        t.equal(s.txt.foo, 'originalUp')
         data.found = true
-        clearTimeout(data.timer)
-        t.equal(s.txt.foo, 'baz')
-        bonjour.destroy()
-        t.end()
-      }
-    })
+        if (!data.updateTxtSent) {
+          data.updateTxtSent = true
+          service.updateTxt({ foo: 'updateUp' })
+        }
+      })
+    }
   })
 })
+
+
+test('bonjour.change and update event', function (bonjour, t) {
+  const data = { updateTxtSent: false, success: false, timer: null, serviceUp: false }
+  data.timer = setTimeout(function () {
+    t.equal(data.success, true)
+    bonjour.destroy()
+    t.end()
+  }, 3000) // Wait for the record to update maximum 3000 ms
+  const service = bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'original' } }).on('up', function () {
+    if (!data.serviceUp) {  // Workaround for Service.up firing when service.updateTxt is used
+      data.serviceUp = true;
+      const browser = bonjour.find({ type: 'test' })
+      browser.on('up', function (s) {
+        t.equal(s.txt.foo, 'original')
+        if (!data.updateTxtSent) {
+          data.updateTxtSent = true
+          service.updateTxt({ foo: 'update' })
+        }
+      })
+
+      browser.on('update', function (s) {
+        if (s.txt.foo === 'update') { // Ignore updates that we are not interested in, have seen updates of just address information
+          t.equal(s.txt.foo, 'update')
+          data.success = true
+          clearTimeout(data.timer);
+          bonjour.destroy()
+          t.end()
+        }
+      })
+    }
+  })
+})
+
 
 test('bonjour.find - binary txt', function (bonjour, t) {
   const next = afterAll(function () {

--- a/test/bonjour.js
+++ b/test/bonjour.js
@@ -126,8 +126,8 @@ test('bonjour.change and up event', function (bonjour, t) {
     t.end()
   }, 3000) // Wait 3000 ms for any additional up messages when the updateTxt is sent
   const service = bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'originalUp' } }).on('up', function () {
-    if (!data.serviceUp) {  // Workaround for Service.up firing when service.updateTxt is used
-      data.serviceUp = true;
+    if (!data.serviceUp) { // Workaround for Service.up firing when service.updateTxt is used
+      data.serviceUp = true
       const browser = bonjour.find({ type: 'test' })
       browser.on('up', function (s) {
         t.equal(s.txt.foo, 'originalUp')
@@ -141,7 +141,6 @@ test('bonjour.change and up event', function (bonjour, t) {
   })
 })
 
-
 test('bonjour.change and update event', function (bonjour, t) {
   const data = { updateTxtSent: false, success: false, timer: null, serviceUp: false }
   data.timer = setTimeout(function () {
@@ -150,8 +149,8 @@ test('bonjour.change and update event', function (bonjour, t) {
     t.end()
   }, 3000) // Wait for the record to update maximum 3000 ms
   const service = bonjour.publish({ name: 'Baz', type: 'test', port: 3000, txt: { foo: 'original' } }).on('up', function () {
-    if (!data.serviceUp) {  // Workaround for Service.up firing when service.updateTxt is used
-      data.serviceUp = true;
+    if (!data.serviceUp) { // Workaround for Service.up firing when service.updateTxt is used
+      data.serviceUp = true
       const browser = bonjour.find({ type: 'test' })
       browser.on('up', function (s) {
         t.equal(s.txt.foo, 'original')
@@ -165,7 +164,7 @@ test('bonjour.change and update event', function (bonjour, t) {
         if (s.txt.foo === 'update') { // Ignore updates that we are not interested in, have seen updates of just address information
           t.equal(s.txt.foo, 'update')
           data.success = true
-          clearTimeout(data.timer);
+          clearTimeout(data.timer)
           bonjour.destroy()
           t.end()
         }
@@ -173,7 +172,6 @@ test('bonjour.change and update event', function (bonjour, t) {
     }
   })
 })
-
 
 test('bonjour.find - binary txt', function (bonjour, t) {
   const next = afterAll(function () {


### PR DESCRIPTION
I was looking at adding the ability to automatically detect changes to accessories and bridges, and needed the capability to receive TXT record updates.  The existing Browser implementation just ignores them, so this pull request adds another event that will emit when a new message is received for an already discovered service.

This change is 100% backwards compatible with existing implementations.