### PR TITLE
Add service name to error message to more easily pinpoint service nam…

### DIFF
--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -105,7 +105,7 @@ Registry.prototype = {
 
     // Handle error
     service.stop()
-    service.emit('error', new Error('Service name is already in use on the network'))
+    service.emit('error', new Error('Service name "' + service.name + '" is already in use on the network'))
   }
 
 }


### PR DESCRIPTION
…e clashes in HAP-nodejs

## :recycle: Current situation

It can get quite annoying to pinpoint which Service is causing Homebridge or HAP-nodejs to fail (in my case it was due to the same service being used in DEV as the service being used by my intercom).

## :bulb: Proposed solution

Add the name of the service to the Error to more clearly reflect which Service needs to be reconfigured.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
