### PR TITLE
chore: remove array-flatten, use native Array.prototype.flat

### DIFF
--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const flatten = require('array-flatten').flatten
 const Service = require('./Service.js')
 const Prober = require('./Prober.js')
 
@@ -45,14 +44,14 @@ Registry.prototype = {
       return service._activated // ignore services not currently starting or started
     })
 
-    const records = flatten(services.map(function (service) {
+    const records = services.map(function (service) {
       service.deactivate()
       const records = service._records(true)
       records.forEach(function (record) {
         record.ttl = 0 // prepare goodbye message
       })
       return records
-    }), 1)
+    }).flat()
 
     if (records.length === 0) { return cb && cb() }
 

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -2,7 +2,6 @@
 
 const multicastdns = require('multicast-dns')
 const dnsEqual = require('./utils/dnsEqual')
-const flatten = require('array-flatten').flatten
 const helpers = require('./helpers.js')
 
 const Server = function (opts) {
@@ -22,7 +21,7 @@ Server.prototype = {
 
       // generate the answers section
       const answers = type === 'ANY'
-        ? flatten(Object.keys(this.registry).map(this._recordsFor.bind(this, name)), 1)
+        ? Object.keys(this.registry).map(this._recordsFor.bind(this, name)).flat()
         : this._recordsFor(name, type)
 
       if (answers.length === 0) return

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "3.9.1",
       "license": "MIT",
       "dependencies": {
-        "array-flatten": "^3.0.0",
         "deep-equal": "^2.2.3",
         "multicast-dns": "^7.2.5",
         "multicast-dns-service-types": "^1.1.0"
@@ -843,12 +842,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/array-flatten": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-3.0.0.tgz",
-      "integrity": "sha512-zPMVc3ZYlGLNk4mpK1NzP2wg0ml9t7fUgDsayR5Y5rSzxQilzR9FGu/EH2jQOcKSAeAfWeylyW8juy3OkWRvNA==",
-      "license": "MIT"
     },
     "node_modules/array-includes": {
       "version": "3.1.9",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "README.md"
   ],
   "dependencies": {
-    "array-flatten": "^3.0.0",
     "deep-equal": "^2.2.3",
     "multicast-dns": "^7.2.5",
     "multicast-dns-service-types": "^1.1.0"


### PR DESCRIPTION
Remove a dependency, because Array.prototype.flat is widely supported

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat