### PR TITLE
v3.10.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Get Release Tag (Latest Only)
         if: steps.release-type.outputs.type == 'latest'
         id: get_version
-        uses: jannemattila/get-version-from-tag@v3
+        uses: jannemattila/get-version-from-tag@v4
 
       - name: Tag Info (Latest Only)
         if: steps.release-type.outputs.type == 'latest'
@@ -158,7 +158,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Create nightly release
         id: create_release
-        uses: viperproject/create-nightly-release@v1
+        uses: viperproject/create-nightly-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 
 - fix(types): align `index.d.ts` with runtime
 - chore: dependency updates
+- fix(server): continue past unanswered questions in multi-question queries
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(browser): compare wildcard PTR name case-insensitively
 - fix(browser): dedup wildcard PTR queries by service type, not parent name
 - fix(prober): unref the initial probe-jitter timer
+- fix(service): restore exponential re-announce backoff
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(server): warn instead of crash when mdns respond fails
 - fix(service): include meta-enumeration PTR in goodbye records
 - fix: surface mdns errors via Bonjour 'error' event
+- chore(ci): bump release workflow action versions
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(server): compare names case-insensitively when unregistering records
 - fix(browser): compare wildcard PTR name case-insensitively
 - fix(browser): dedup wildcard PTR queries by service type, not parent name
+- fix(prober): unref the initial probe-jitter timer
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(service): restore exponential re-announce backoff
 - fix(service): don't resurrect torn-down services in announce callback
 - fix(browser): suppress no-op 'update' events when nothing changed
+- fix: broadcast goodbye records during Bonjour.destroy()
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(types): align `index.d.ts` with runtime
 - chore: dependency updates
 - fix(server): continue past unanswered questions in multi-question queries
+- fix(browser): handle null opts in constructor
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(service): make stop() callback truly optional
 - fix(server): compare names case-insensitively when unregistering records
 - fix(browser): compare wildcard PTR name case-insensitively
+- fix(browser): dedup wildcard PTR queries by service type, not parent name
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(browser): dedup wildcard PTR queries by service type, not parent name
 - fix(prober): unref the initial probe-jitter timer
 - fix(service): restore exponential re-announce backoff
+- fix(service): don't resurrect torn-down services in announce callback
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(prober): unref the initial probe-jitter timer
 - fix(service): restore exponential re-announce backoff
 - fix(service): don't resurrect torn-down services in announce callback
+- fix(browser): suppress no-op 'update' events when nothing changed
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(browser): suppress no-op 'update' events when nothing changed
 - fix: broadcast goodbye records during Bonjour.destroy()
 - fix(server): warn instead of crash when mdns respond fails
+- fix(service): include meta-enumeration PTR in goodbye records
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(server): continue past unanswered questions in multi-question queries
 - fix(browser): handle null opts in constructor
 - fix(service): make stop() callback truly optional
+- fix(server): compare names case-insensitively when unregistering records
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(service): don't resurrect torn-down services in announce callback
 - fix(browser): suppress no-op 'update' events when nothing changed
 - fix: broadcast goodbye records during Bonjour.destroy()
+- fix(server): warn instead of crash when mdns respond fails
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix: broadcast goodbye records during Bonjour.destroy()
 - fix(server): warn instead of crash when mdns respond fails
 - fix(service): include meta-enumeration PTR in goodbye records
+- fix: surface mdns errors via Bonjour 'error' event
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to `bonjour-hap` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v3.10.3 (Pending Release)
+
+- fix(types): align `index.d.ts` with runtime
+
 ## v3.10.2 (2026-05-04)
 
 - add `.DS_Store` and `.idea` to `gitignore` file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - chore: dependency updates
 - fix(server): continue past unanswered questions in multi-question queries
 - fix(browser): handle null opts in constructor
+- fix(service): make stop() callback truly optional
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 ## v3.10.3 (Pending Release)
 
 - fix(types): align `index.d.ts` with runtime
+- chore: dependency updates
 
 ## v3.10.2 (2026-05-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(browser): handle null opts in constructor
 - fix(service): make stop() callback truly optional
 - fix(server): compare names case-insensitively when unregistering records
+- fix(browser): compare wildcard PTR name case-insensitively
 
 ## v3.10.2 (2026-05-04)
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,57 +1,144 @@
-import { SocketOptions } from "dgram";
+import { RemoteInfo, Socket } from "dgram";
 
-export type BonjourFindOptions = {
-  type: string;
-  subtypes?: string[];
+/**
+ * Options accepted by the underlying multicast-dns responder.
+ * Forwarded by `Bonjour(options)` straight into `multicast-dns`.
+ */
+export interface MulticastOptions {
+  /** Multicast port. Defaults to 5353. */
+  port?: number;
+  /** Socket type. Defaults to 'udp4'. */
+  type?: "udp4" | "udp6";
+  /** Multicast IP address. Defaults to 224.0.0.251 for udp4. Required for udp6. */
+  ip?: string;
+  /** Alias for `ip`. */
+  host?: string;
+  /** Interface name. Required for IPv6 multicast. */
+  interface?: string;
+  /** Whether to allow address reuse. Defaults to true. */
+  reuseAddr?: boolean;
+  /** Pre-created dgram socket. */
+  socket?: Socket;
+  /** Whether to join the multicast group. Defaults to true. */
+  multicast?: boolean;
+  /** Multicast TTL. Defaults to 255. */
+  ttl?: number;
+  /** Multicast loopback. Defaults to true. */
+  loopback?: boolean;
+  /** Bind address, or `false` to skip binding. */
+  bind?: string | false;
+}
+
+export interface BonjourFindOptions {
+  /** If omitted, performs a wildcard search across all service types. */
+  type?: string;
+  /** Defaults to 'tcp'. */
   protocol?: "tcp" | "udp";
-  txt?: Record<string, any>;
-};
+  /** Filter to a specific service instance name. */
+  name?: string;
+  /** Options forwarded to the TXT record decoder. */
+  txt?: { binary?: boolean };
+}
 
+/**
+ * A service discovered via {@link Bonjour.find} / {@link Bonjour.findOne}.
+ *
+ * Populated from incoming SRV/TXT/A/AAAA records. Services without a matching
+ * SRV record are filtered out before being emitted, so all SRV-derived fields
+ * are guaranteed to be present on emitted services.
+ */
 export interface BonjourService {
+  name: string;
+  fqdn: string;
+  type: string;
+  subtypes: string[];
+  protocol: "tcp" | "udp";
+  host: string;
+  port: number;
+  referer: RemoteInfo;
+  addresses: string[];
+  /** Decoded TXT record, if a TXT record was received. */
+  txt?: Record<string, string>;
+  /** Raw TXT record blocks, if a TXT record was received. */
+  rawTxt?: Buffer[];
+}
+
+export interface Browser {
+  /** Currently-known services. Updated as services come up, change, or go down. */
+  services: BonjourService[];
+
+  start(): void;
+  stop(): void;
+  /** Send a fresh PTR query to refresh the service list. */
+  update(): void;
+
+  on(event: "up" | "down" | "update", listener: (service: BonjourService) => void): this;
+}
+
+/**
+ * A service published via {@link Bonjour.publish}. Returned to the caller so
+ * they can update the TXT record, stop, or destroy the advertisement.
+ */
+export interface Advertisement {
   name: string;
   type: string;
   protocol: "tcp" | "udp";
   host: string;
   port: number;
-  addresses: string[];
-  txt: Record<string, string>;
-  rawTxt?: Buffer;
-}
+  fqdn: string;
+  subtypes: string[] | null;
+  txt: Record<string, string> | null;
+  /** True once the initial announcement has been confirmed. */
+  published: boolean;
 
-export interface MulticastOptions extends SocketOptions {
-  multicastAddress?: string;
-  multicastInterface?: string;
-  multicastTTL?: number;
-  reuseAddr?: boolean;
-}
-
-export class Browser {
   start(): void;
-  stop(): void;
-  update(): void;
-  on(event: "up" | "down", listener: (service: BonjourService) => void): this;
-}
+  /**
+   * Stop advertising. The callback is required if the service has not been
+   * activated yet (the runtime calls it synchronously in that case).
+   */
+  stop(callback?: () => void): void;
+  /** Tear down the service and remove all listeners. */
+  destroy(): void;
+  /** Replace the TXT record. If `silent` is true, the new record is registered but not re-announced. */
+  updateTxt(txt: Record<string, string>, silent?: boolean): void;
 
-export class Advertisement {
-  stop(): void;
-  start(): void;
-  update(txt: Record<string, string>): void;
+  /** Emitted once after the first successful announcement. */
+  on(event: "up", listener: () => void): this;
+  /** Emitted if the service name is already in use on the network. */
   on(event: "error", listener: (err: Error) => void): this;
 }
 
 export interface PublishOptions {
   name: string;
   type: string;
-  subtypes?: string[];
   port: number;
   host?: string;
-  txt?: Record<string, string>;
   protocol?: "tcp" | "udp";
+  subtypes?: string[];
+  txt?: Record<string, string>;
+  /** Probe for name conflicts before announcing. Defaults to true. */
+  probe?: boolean;
+
+  /**
+   * Adds a meta enumeration record (`_services._dns-sd._udp.local`) when announcing.
+   * Only safe to enable when a single service is advertised on the responder, otherwise
+   * removing one service will break enumeration for the others.
+   */
+  addUnsafeServiceEnumerationRecord?: boolean;
+
+  /**
+   * Restricts the service to be advertised on the specified IP addresses or interface names.
+   * Interface names and addresses can be mixed.
+   * If an interface name is given, ANY address on that interface is advertised.
+   * If an IP address is given, only that address is advertised.
+   */
+  restrictedAddresses?: string[];
+
+  /** If true, the service will not advertise IPv6 (AAAA) records. */
+  disabledIpv6?: boolean;
 }
 
-export default class Bonjour {
-  constructor(options?: MulticastOptions);
-
+export interface Bonjour {
   publish(options: PublishOptions): Advertisement;
   unpublishAll(callback?: () => void): void;
   find(
@@ -60,7 +147,15 @@ export default class Bonjour {
   ): Browser;
   findOne(
     options: BonjourFindOptions,
-    callback: (service: BonjourService) => void
+    callback?: (service: BonjourService) => void
   ): Browser;
   destroy(): void;
 }
+
+export interface BonjourFactory {
+  new (options?: MulticastOptions): Bonjour;
+  (options?: MulticastOptions): Bonjour;
+}
+
+declare const Bonjour: BonjourFactory;
+export default Bonjour;

--- a/index.d.ts
+++ b/index.d.ts
@@ -149,7 +149,12 @@ export interface Bonjour {
     options: BonjourFindOptions,
     callback?: (service: BonjourService) => void
   ): Browser;
-  destroy(): void;
+  /**
+   * Tear down the responder. Goodbye records are broadcast for every
+   * published service before the underlying mdns socket is closed.
+   * The optional callback fires once teardown is complete.
+   */
+  destroy(callback?: () => void): void;
 }
 
 export interface BonjourFactory {

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,6 +155,12 @@ export interface Bonjour {
    * The optional callback fires once teardown is complete.
    */
   destroy(callback?: () => void): void;
+  /**
+   * Emitted when the underlying mdns socket reports an error or an
+   * outgoing response fails. If no listener is attached, the error is
+   * logged to `console.warn` so it does not crash the process.
+   */
+  on(event: "error", listener: (err: Error) => void): this;
 }
 
 export interface BonjourFactory {

--- a/index.js
+++ b/index.js
@@ -33,9 +33,11 @@ Bonjour.prototype = {
     return browser
   },
 
-  destroy: function () {
-    this._registry.destroy()
-    this._server.mdns.destroy()
+  destroy: function (cb) {
+    this._registry.destroy(() => {
+      this._server.mdns.destroy()
+      if (cb) cb()
+    })
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict'
 
+const util = require('util')
+const EventEmitter = require('events').EventEmitter
 const Registry = require('./lib/Registry.js')
 const Server = require('./lib/Server.js')
 const Browser = require('./lib/Browser.js')
@@ -7,11 +9,22 @@ const Browser = require('./lib/Browser.js')
 function Bonjour (opts) {
   if (!(this instanceof Bonjour)) { return new Bonjour(opts) }
 
+  EventEmitter.call(this)
+
   this._server = new Server(opts)
   this._registry = new Registry(this._server)
+  this._server.on('error', err => {
+    if (this.listenerCount('error') > 0) {
+      this.emit('error', err)
+    } else {
+      console.warn('bonjour-hap:', err.message || err)
+    }
+  })
 }
 
-Bonjour.prototype = {
+util.inherits(Bonjour, EventEmitter)
+
+Object.assign(Bonjour.prototype, {
   publish: function (opts) {
     return this._registry.publish(opts)
   },
@@ -39,6 +52,6 @@ Bonjour.prototype = {
       if (cb) cb()
     })
   }
-}
+})
 
 module.exports = Bonjour

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -67,7 +67,7 @@ Browser.prototype.start = function () {
   this._onresponse = function (packet, rinfo) {
     if (self._wildcard) {
       packet.answers.forEach(function (answer) {
-        if (answer.type !== 'PTR' || !dnsEqual(answer.name, self._name) || answer.name in nameMap) return
+        if (answer.type !== 'PTR' || !dnsEqual(answer.name, self._name) || answer.data in nameMap) return
         nameMap[answer.data] = true
         self._mdns.query(answer.data, 'PTR')
       })

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -3,6 +3,7 @@
 const util = require('util')
 const EventEmitter = require('events').EventEmitter
 const serviceName = require('multicast-dns-service-types')
+const deepEqual = require('fast-deep-equal')
 const dnsEqual = require('./utils/dnsEqual')
 const dnsTxt = require('./utils/txtDecoder')
 
@@ -123,8 +124,17 @@ Browser.prototype._updateService = function (service) {
     return false
   })
   if (!cachedService) return
+  if (!serviceChanged(cachedService, service)) return
   this.services[index] = service
   this.emit('update', service)
+}
+
+function serviceChanged (a, b) {
+  return a.host !== b.host ||
+    a.port !== b.port ||
+    !deepEqual(a.addresses, b.addresses) ||
+    !deepEqual(a.subtypes, b.subtypes) ||
+    !deepEqual(a.txt, b.txt)
 }
 
 Browser.prototype._removeService = function (fqdn) {

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -35,7 +35,7 @@ function Browser (mdns, opts, onup) {
   this._mdns = mdns
   this._onresponse = null
   this._serviceMap = {}
-  this._txt = dnsTxt(opts.txt)
+  this._txt = dnsTxt(opts && opts.txt)
 
   if (!opts || !opts.type) {
     this._name = WILDCARD

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -67,7 +67,7 @@ Browser.prototype.start = function () {
   this._onresponse = function (packet, rinfo) {
     if (self._wildcard) {
       packet.answers.forEach(function (answer) {
-        if (answer.type !== 'PTR' || answer.name !== self._name || answer.name in nameMap) return
+        if (answer.type !== 'PTR' || !dnsEqual(answer.name, self._name) || answer.name in nameMap) return
         nameMap[answer.data] = true
         self._mdns.query(answer.data, 'PTR')
       })

--- a/lib/Prober.js
+++ b/lib/Prober.js
@@ -30,7 +30,7 @@ Prober.prototype = {
 
   start: function () {
     this.mdns.on('response', this.bound)
-    setTimeout(this.try.bind(this), Math.random() * 250)
+    setTimeout(this.try.bind(this), Math.random() * 250).unref()
   },
 
   try: function () {

--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -51,7 +51,7 @@ Registry.prototype = {
 
     const records = services.map(function (service) {
       service.deactivate()
-      const records = service._records(true)
+      const records = service._records()
       records.forEach(function (record) {
         record.ttl = 0 // prepare goodbye message
       })

--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -26,8 +26,13 @@ Registry.prototype = {
     this._services = []
   },
 
-  destroy: function () {
-    for (let i = 0; i < this._services.length; i++) { this._services[i].destroy() }
+  destroy: function (cb) {
+    const services = this._services.slice()
+    this._services = []
+    this._tearDown(services, () => {
+      for (let i = 0; i < services.length; i++) { services[i].destroy() }
+      if (cb) cb()
+    })
   },
 
   /**

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -57,7 +57,7 @@ Server.prototype = {
         answers,
         additionals
       }, err => {
-        if (err) throw err // TODO: Handle this (if no callback is given, the error will be ignored)
+        if (err) console.warn('bonjour-hap: mdns respond failed:', err.message || err)
       })
     }
   },

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,17 +1,23 @@
 'use strict'
 
+const util = require('util')
+const EventEmitter = require('events').EventEmitter
 const multicastdns = require('multicast-dns')
 const dnsEqual = require('./utils/dnsEqual')
 const helpers = require('./helpers.js')
 
 const Server = function (opts) {
+  EventEmitter.call(this)
   this.mdns = multicastdns(opts)
   this.mdns.setMaxListeners(0)
   this.registry = {}
   this.mdns.on('query', this._respondToQuery.bind(this))
+  this.mdns.on('error', err => this.emit('error', err))
 }
 
-Server.prototype = {
+util.inherits(Server, EventEmitter)
+
+Object.assign(Server.prototype, {
   _respondToQuery: function (query) {
     for (let i = 0; i < query.questions.length; i++) {
       const question = query.questions[i]
@@ -57,7 +63,7 @@ Server.prototype = {
         answers,
         additionals
       }, err => {
-        if (err) console.warn('bonjour-hap: mdns respond failed:', err.message || err)
+        if (err) this.emit('error', err)
       })
     }
   },
@@ -103,6 +109,6 @@ Server.prototype = {
     })
   }
 
-}
+})
 
 module.exports = Server

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -89,7 +89,7 @@ Server.prototype = {
       if (!(type in this.registry)) { continue }
 
       this.registry[type] = this.registry[type].filter(r => {
-        return r.name !== record.name
+        return !dnsEqual(r.name, record.name)
       })
     }
   },

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -24,7 +24,7 @@ Server.prototype = {
         ? Object.keys(this.registry).map(this._recordsFor.bind(this, name)).flat()
         : this._recordsFor(name, type)
 
-      if (answers.length === 0) return
+      if (answers.length === 0) continue
 
       // generate the additionals section
       let additionals = []

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -109,6 +109,11 @@ const proto = {
     if (this.timer) { clearTimeout(this.timer) }
 
     this.delay = 1000
+    this._emitAnnounce(silent)
+  },
+
+  _emitAnnounce: function (silent) {
+    if (this._destroyed) { return }
     this.emit('service-announce-request', this.packet, silent || false, this.onAnnounceComplete.bind(this))
   },
 
@@ -121,7 +126,7 @@ const proto = {
 
     this.delay = this.delay * REANNOUNCE_FACTOR
     if (this.delay < REANNOUNCE_MAX_MS && !this._destroyed && this._activated) {
-      this.timer = setTimeout(this.announce.bind(this), this.delay).unref()
+      this.timer = setTimeout(this._emitAnnounce.bind(this), this.delay).unref()
     } else {
       this.timer = undefined
       this.delay = undefined

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -118,14 +118,15 @@ const proto = {
   },
 
   onAnnounceComplete: function () {
+    if (this._destroyed || !this._activated) return
+
     if (!this.published) {
-      this._activated = true // not sure if this is needed here
       this.published = true
       this.emit('up')
     }
 
     this.delay = this.delay * REANNOUNCE_FACTOR
-    if (this.delay < REANNOUNCE_MAX_MS && !this._destroyed && this._activated) {
+    if (this.delay < REANNOUNCE_MAX_MS) {
       this.timer = setTimeout(this._emitAnnounce.bind(this), this.delay).unref()
     } else {
       this.timer = undefined

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -83,7 +83,7 @@ const proto = {
 
   stop: function (cb) {
     if (!this._activated) {
-      cb()
+      if (cb) cb()
       return
     }
 

--- a/lib/Service.js
+++ b/lib/Service.js
@@ -151,12 +151,12 @@ const proto = {
     this.published = false
   },
 
-  _records: function (teardown) {
+  _records: function () {
     const records = [this._rrPtr(), this._rrSrv(), this._rrTxt()]
 
     records.push(...this._addressRecords())
 
-    if (!teardown && this.addUnsafeServiceEnumerationRecord) {
+    if (this.addUnsafeServiceEnumerationRecord) {
       records.push(this._rrMetaPtr())
     }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -634,9 +634,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -977,9 +977,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.27",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
-      "integrity": "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==",
+      "version": "2.10.32",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
+      "integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -990,9 +990,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001791",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001791.tgz",
-      "integrity": "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ==",
+      "version": "1.0.30001793",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+      "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
       "dev": true,
       "funding": [
         {
@@ -1517,9 +1517,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.349",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.349.tgz",
-      "integrity": "sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==",
+      "version": "1.5.361",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
+      "integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
       "dev": true,
       "license": "ISC"
     },
@@ -1679,9 +1679,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3341,13 +3341,13 @@
       }
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
-      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "version": "2.16.2",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.2.tgz",
+      "integrity": "sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hasown": "^2.0.2"
+        "hasown": "^2.0.3"
       },
       "engines": {
         "node": ">= 0.4"
@@ -4210,11 +4210,14 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.38.tgz",
-      "integrity": "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw==",
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
+      "integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/nyc": {
       "version": "18.0.0",
@@ -4601,9 +4604,9 @@
       }
     },
     "node_modules/path-scurry/node_modules/lru-cache": {
-      "version": "11.3.5",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
-      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "version": "11.5.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.0.tgz",
+      "integrity": "sha512-5YgH9UJd7wVb9hIouI2adWpgqrrICkt070Dnj8EUY1+B4B2P9eRLPAkAAo6NICA7CEhOIeBHl46u9zSNpNu7zA==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4875,14 +4878,14 @@
       "license": "ISC"
     },
     "node_modules/resolve": {
-      "version": "2.0.0-next.6",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.6.tgz",
-      "integrity": "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA==",
+      "version": "2.0.0-next.7",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-2.0.0-next.7.tgz",
+      "integrity": "sha512-tqt+NBWwyaMgw3zDsnygx4CByWjQEJHOPMdslYhppaQSJUtL/D4JO9CcBBlhPoI8lz9oJIDXkwXfhF4aWqP8xQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "is-core-module": "^2.16.1",
+        "is-core-module": "^2.16.2",
         "node-exports-info": "^1.6.0",
         "object-keys": "^1.1.1",
         "path-parse": "^1.0.7",
@@ -5019,9 +5022,9 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "dev": true,
       "license": "ISC",
       "bin": {

--- a/test/regression.js
+++ b/test/regression.js
@@ -151,3 +151,50 @@ tape('Browser wildcard accepts a meta-enumeration PTR with mixed-case name', fun
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === 61d9f11 — Browser: dedup wildcard PTR queries by service type, not parent name ===
+
+tape('Browser wildcard does not re-query for an already-discovered service type', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const queries = []
+    bonjour._server.mdns.query = function (name, type) { queries.push({ name, type }) }
+
+    const browser = bonjour.find()
+    queries.length = 0
+
+    const packet = {
+      answers: [{ type: 'PTR', name: '_services._dns-sd._udp.local', data: '_http._tcp.local' }],
+      additionals: []
+    }
+    browser._onresponse(packet, { address: '127.0.0.1', port: 5353 })
+    browser._onresponse(packet, { address: '127.0.0.1', port: 5353 })
+
+    const httpQueries = queries.filter(function (q) { return q.name === '_http._tcp.local' })
+    t.equal(httpQueries.length, 1, 'second identical PTR did not trigger another query')
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Browser wildcard still queries for distinct service types', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const queries = []
+    bonjour._server.mdns.query = function (name, type) { queries.push({ name, type }) }
+
+    const browser = bonjour.find()
+    queries.length = 0
+
+    browser._onresponse({
+      answers: [
+        { type: 'PTR', name: '_services._dns-sd._udp.local', data: '_http._tcp.local' },
+        { type: 'PTR', name: '_services._dns-sd._udp.local', data: '_ftp._tcp.local' }
+      ],
+      additionals: []
+    }, { address: '127.0.0.1', port: 5353 })
+
+    t.ok(queries.some(function (q) { return q.name === '_http._tcp.local' }), 'queried http')
+    t.ok(queries.some(function (q) { return q.name === '_ftp._tcp.local' }), 'queried ftp')
+    bonjour.destroy(function () { t.end() })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -228,3 +228,67 @@ tape('Prober.start() unrefs the initial jitter timer', function (t) {
   t.equal(firstFake.hasRef(), false, "jitter timer is unref'd so it does not block process exit")
   t.end()
 })
+
+// === 025e0cd — Service: restore exponential re-announce backoff ===
+
+tape('Service re-announce delay accumulates 3x across timer firings', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  s._activated = true
+  s.packet = s._records()
+
+  const realSetTimeout = global.setTimeout
+  const scheduled = []
+  global.setTimeout = function (fn, delay) {
+    scheduled.push({ fn, delay })
+    return { unref: function () { return this } }
+  }
+
+  let pendingCb
+  s.on('service-announce-request', function (pkt, silent, cb) { pendingCb = cb })
+
+  s.announce()
+  pendingCb()
+  t.equal(scheduled[0].delay, 3000, 'first re-announce scheduled at 3 s')
+
+  scheduled[0].fn()
+  pendingCb()
+  t.equal(scheduled[1].delay, 9000, 'second re-announce at 9 s (multiplier accumulated, not reset)')
+
+  scheduled[1].fn()
+  pendingCb()
+  t.equal(scheduled[2].delay, 27000, 'third re-announce at 27 s')
+
+  global.setTimeout = realSetTimeout
+  s._destroyed = true
+  t.end()
+})
+
+tape('Service.announce() (public entry) resets delay back to 1 s', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  s._activated = true
+  s.packet = s._records()
+
+  const realSetTimeout = global.setTimeout
+  const scheduled = []
+  global.setTimeout = function (fn, delay) {
+    scheduled.push({ fn, delay })
+    return { unref: function () { return this } }
+  }
+
+  let pendingCb
+  s.on('service-announce-request', function (pkt, silent, cb) { pendingCb = cb })
+
+  s.announce()
+  pendingCb()
+  scheduled[0].fn()
+  pendingCb()
+  t.equal(scheduled[1].delay, 9000, 'walked the timer chain to 9 s')
+
+  s.announce()
+  pendingCb()
+  t.equal(scheduled[2].delay, 3000, 'public announce() reset delay back to 1 s')
+
+  global.setTimeout = realSetTimeout
+  s._destroyed = true
+  t.end()
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -388,3 +388,45 @@ tape('Browser still emits update when user-visible TXT actually changes', functi
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === f5e1333 — Bonjour.destroy() broadcasts goodbye records ===
+
+tape('Bonjour.destroy() broadcasts ttl=0 goodbye PTR records before closing', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    const respondCalls = []
+    const orig = bonjour._server.mdns.respond.bind(bonjour._server.mdns)
+    bonjour._server.mdns.respond = function (records) {
+      respondCalls.push(records)
+      return orig.apply(null, arguments)
+    }
+
+    bonjour.publish({ name: 'GoodbyeTest', type: 'goodbye', port: 3000, probe: false })
+      .on('up', function () {
+        const announceCount = respondCalls.length
+        bonjour.destroy(function () {
+          const newCalls = respondCalls.slice(announceCount)
+          const allRecords = newCalls.flatMap(function (rs) { return Array.isArray(rs) ? rs : [rs] })
+          const goodbyePtrs = allRecords.filter(function (r) { return r.type === 'PTR' && r.ttl === 0 })
+          t.ok(goodbyePtrs.length > 0, 'at least one ttl=0 PTR record was broadcast')
+          t.ok(goodbyePtrs.some(function (r) { return r.data === 'GoodbyeTest._goodbye._tcp.local' }),
+            'goodbye for our service was broadcast')
+          t.end()
+        })
+      })
+  })
+})
+
+tape('Bonjour.destroy(cb) callback fires after teardown completes', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    bonjour.publish({ name: 'CbTest', type: 'cbtest', port: 3000, probe: false })
+      .on('up', function () {
+        bonjour.destroy(function () {
+          t.pass('destroy callback fired')
+          t.end()
+        })
+      })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -198,3 +198,33 @@ tape('Browser wildcard still queries for distinct service types', function (t) {
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === c0fc44d — Prober: unref the initial probe-jitter timer ===
+
+tape('Prober.start() unrefs the initial jitter timer', function (t) {
+  const realSetTimeout = global.setTimeout
+  let firstFake = null
+  global.setTimeout = function (fn, delay) {
+    if (firstFake === null) {
+      let refed = true
+      firstFake = {
+        unref: function () { refed = false; return this },
+        ref: function () { refed = true; return this },
+        hasRef: function () { return refed }
+      }
+      return firstFake
+    }
+    return realSetTimeout(fn, delay)
+  }
+
+  const fakeMdns = { on: function () {}, query: function () {}, removeListener: function () {} }
+  const fakeService = { _activated: true, _destroyed: false, fqdn: 'foo._tcp.local' }
+  const prober = new Prober(fakeMdns, fakeService, function () {})
+  prober.start()
+
+  global.setTimeout = realSetTimeout
+
+  t.ok(firstFake, 'jitter timer was scheduled')
+  t.equal(firstFake.hasRef(), false, "jitter timer is unref'd so it does not block process exit")
+  t.end()
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -459,3 +459,68 @@ tape('mdns.respond callback error does not raise uncaughtException', function (t
     }, 50)
   })
 })
+
+// === ab7d952 — meta-enumeration PTR included in goodbye records ===
+
+tape('goodbye includes meta-enum PTR for addUnsafeServiceEnumerationRecord services', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    const respondCalls = []
+    const orig = bonjour._server.mdns.respond.bind(bonjour._server.mdns)
+    bonjour._server.mdns.respond = function (records) {
+      respondCalls.push(records)
+      return orig.apply(null, arguments)
+    }
+
+    const service = bonjour.publish({
+      name: 'MetaTest',
+      type: 'meta',
+      port: 3000,
+      probe: false,
+      addUnsafeServiceEnumerationRecord: true
+    })
+
+    service.on('up', function () {
+      const announceCount = respondCalls.length
+      service.stop(function () {
+        const newCalls = respondCalls.slice(announceCount)
+        const allRecords = newCalls.flatMap(function (rs) { return Array.isArray(rs) ? rs : [rs] })
+        const metaGoodbye = allRecords.filter(function (r) {
+          return r.name === '_services._dns-sd._udp.local' && r.type === 'PTR' && r.ttl === 0
+        })
+        t.ok(metaGoodbye.length > 0, 'meta-enum PTR included in goodbye records')
+        t.equal(metaGoodbye[0].data, '_meta._tcp.local')
+        bonjour.destroy(function () { t.end() })
+      })
+    })
+  })
+})
+
+tape('goodbye for a non-meta service does not emit a meta-enum PTR', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    const respondCalls = []
+    const orig = bonjour._server.mdns.respond.bind(bonjour._server.mdns)
+    bonjour._server.mdns.respond = function (records) {
+      respondCalls.push(records)
+      return orig.apply(null, arguments)
+    }
+
+    const service = bonjour.publish({ name: 'NoMeta', type: 'plain', port: 3000, probe: false })
+
+    service.on('up', function () {
+      const announceCount = respondCalls.length
+      service.stop(function () {
+        const newCalls = respondCalls.slice(announceCount)
+        const allRecords = newCalls.flatMap(function (rs) { return Array.isArray(rs) ? rs : [rs] })
+        const metaGoodbye = allRecords.filter(function (r) {
+          return r.name === '_services._dns-sd._udp.local' && r.type === 'PTR'
+        })
+        t.equal(metaGoodbye.length, 0, 'no meta-enum PTR when service did not advertise one')
+        bonjour.destroy(function () { t.end() })
+      })
+    })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -100,3 +100,32 @@ tape('Service.stop(cb) on inactive service still invokes the callback', function
     t.end()
   })
 })
+
+// === 3138182 — Server.unregister: case-insensitive name comparison ===
+
+tape('Server.unregister matches names case-insensitively', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+    server.register({ name: 'Foo._TCP.local', type: 'PTR', ttl: 120, data: 'x' })
+    t.equal(server.registry.PTR.length, 1, 'precondition: registered')
+    server.unregister({ name: 'foo._tcp.LOCAL', type: 'PTR', ttl: 120, data: 'x' })
+    t.equal(server.registry.PTR.length, 0, 'removed despite different casing')
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Server.unregister leaves non-matching records intact', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+    server.register([
+      { name: 'A._tcp.local', type: 'PTR', ttl: 120, data: 'a' },
+      { name: 'B._tcp.local', type: 'PTR', ttl: 120, data: 'b' }
+    ])
+    server.unregister({ name: 'a._TCP.LOCAL', type: 'PTR', ttl: 120, data: 'a' })
+    t.equal(server.registry.PTR.length, 1, 'one record left')
+    t.equal(server.registry.PTR[0].name, 'B._tcp.local', 'B was not removed')
+    bonjour.destroy(function () { t.end() })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -129,3 +129,25 @@ tape('Server.unregister leaves non-matching records intact', function (t) {
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === 8d8d9aa — Browser: wildcard meta-PTR name comparison is case-insensitive ===
+
+tape('Browser wildcard accepts a meta-enumeration PTR with mixed-case name', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const queries = []
+    bonjour._server.mdns.query = function (name, type) { queries.push({ name, type }) }
+
+    const browser = bonjour.find()
+    queries.length = 0
+
+    browser._onresponse({
+      answers: [{ type: 'PTR', name: '_Services._DNS-SD._UDP.local', data: '_http._tcp.local' }],
+      additionals: []
+    }, { address: '127.0.0.1', port: 5353 })
+
+    t.ok(queries.some(function (q) { return q.name === '_http._tcp.local' }),
+      'queried for the service type carried by a mixed-case meta-PTR')
+    bonjour.destroy(function () { t.end() })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -524,3 +524,44 @@ tape('goodbye for a non-meta service does not emit a meta-enum PTR', function (t
     })
   })
 })
+
+// === aa7c289 — surface mdns errors via Bonjour 'error' event ===
+
+tape('Bonjour emits error event when mdns.respond callback fails', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    let received = null
+    bonjour.on('error', function (err) { received = err })
+
+    bonjour._server.mdns.respond = function (records, cb) {
+      setImmediate(function () { if (cb) cb(new Error('boom')) })
+    }
+
+    bonjour._server.register({ name: 'X._tcp.local', type: 'PTR', ttl: 120, data: 'a' })
+    bonjour._server._respondToQuery({ questions: [{ name: 'X._tcp.local', type: 'PTR' }] })
+
+    setTimeout(function () {
+      t.ok(received instanceof Error, 'error event fired')
+      t.equal(received.message, 'boom')
+      bonjour.destroy(function () { t.end() })
+    }, 50)
+  })
+})
+
+tape('Bonjour forwards underlying mdns socket errors via the error event', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    let received = null
+    bonjour.on('error', function (err) { received = err })
+
+    bonjour._server.mdns.emit('error', new Error('socket boom'))
+
+    setImmediate(function () {
+      t.ok(received instanceof Error, 'socket error forwarded')
+      t.equal(received.message, 'socket boom')
+      bonjour.destroy(function () { t.end() })
+    })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -337,3 +337,54 @@ tape('onAnnounceComplete bails out for destroyed services', function (t) {
   t.equal(s.published, false, 'destroyed service not marked published')
   t.end()
 })
+
+// === 7768312 — Browser: suppress no-op 'update' events when nothing changed ===
+
+const buildAnnouncePacket = function (txtBlocks) {
+  return {
+    answers: [
+      { type: 'PTR', name: '_test._tcp.local', ttl: 4500, data: 'X._test._tcp.local' },
+      { type: 'SRV', name: 'X._test._tcp.local', ttl: 120, data: { port: 3000, target: 'host.local' } },
+      { type: 'TXT', name: 'X._test._tcp.local', ttl: 4500, data: txtBlocks },
+      { type: 'A', name: 'host.local', ttl: 120, data: '10.0.0.1' }
+    ],
+    additionals: []
+  }
+}
+
+tape('Browser does not emit update for repeated identical announcements', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const browser = bonjour.find({ type: 'test' })
+
+    let upCount = 0
+    let updateCount = 0
+    browser.on('up', function () { upCount++ })
+    browser.on('update', function () { updateCount++ })
+
+    browser._onresponse(buildAnnouncePacket([Buffer.from('a=1')]), { address: '127.0.0.1', port: 5353 })
+    // re-announce from a different referer — only the rinfo changes, not the service
+    browser._onresponse(buildAnnouncePacket([Buffer.from('a=1')]), { address: '127.0.0.2', port: 5353 })
+    browser._onresponse(buildAnnouncePacket([Buffer.from('a=1')]), { address: '127.0.0.3', port: 5353 })
+
+    t.equal(upCount, 1, 'up emitted once')
+    t.equal(updateCount, 0, "no 'update' for identical re-announces")
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Browser still emits update when user-visible TXT actually changes', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const browser = bonjour.find({ type: 'test' })
+
+    let updateCount = 0
+    browser.on('update', function () { updateCount++ })
+
+    browser._onresponse(buildAnnouncePacket([Buffer.from('a=1')]), { address: '127.0.0.1', port: 5353 })
+    browser._onresponse(buildAnnouncePacket([Buffer.from('a=2')]), { address: '127.0.0.1', port: 5353 })
+
+    t.equal(updateCount, 1, 'update fires once when TXT changed')
+    bonjour.destroy(function () { t.end() })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -430,3 +430,32 @@ tape('Bonjour.destroy(cb) callback fires after teardown completes', function (t)
       })
   })
 })
+
+// === 48c0393 — Server: warn instead of crash when mdns.respond callback errors ===
+
+tape('mdns.respond callback error does not raise uncaughtException', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+
+    let uncaught = null
+    const onUncaught = function (err) { uncaught = err }
+    process.on('uncaughtException', onUncaught)
+
+    // attach an error listener so that, in versions where the server emits
+    // 'error' rather than warning, the EventEmitter does not itself raise
+    bonjour.on('error', function () {})
+
+    bonjour._server.mdns.respond = function (records, cb) {
+      setImmediate(function () { if (cb) cb(new Error('post-shutdown send error')) })
+    }
+
+    bonjour._server.register({ name: 'X._tcp.local', type: 'PTR', ttl: 120, data: 'a' })
+    bonjour._server._respondToQuery({ questions: [{ name: 'X._tcp.local', type: 'PTR' }] })
+
+    setTimeout(function () {
+      process.removeListener('uncaughtException', onUncaught)
+      t.equal(uncaught, null, 'no uncaughtException from a benign respond callback error')
+      bonjour.destroy(function () { t.end() })
+    }, 50)
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -64,3 +64,22 @@ tape('Server answers each question independently in multi-question packets', fun
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === 4a620ff — Browser: handle null opts in constructor ===
+
+tape('Browser does not throw when opts is explicitly null', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    t.doesNotThrow(function () { bonjour.find(null, function () {}) })
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Browser supports the find(fn) shorthand (recurses with null opts)', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    // eslint-disable-next-line array-callback-return
+    t.doesNotThrow(function () { bonjour.find(function () {}) })
+    bonjour.destroy(function () { t.end() })
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -83,3 +83,20 @@ tape('Browser supports the find(fn) shorthand (recurses with null opts)', functi
     bonjour.destroy(function () { t.end() })
   })
 })
+
+// === 5d21b57 — Service.stop() callback truly optional ===
+
+tape('Service.stop() does not throw when called without callback on inactive service', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  t.equal(s._activated, false, 'precondition: service is inactive')
+  t.doesNotThrow(function () { s.stop() })
+  t.end()
+})
+
+tape('Service.stop(cb) on inactive service still invokes the callback', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  s.stop(function () {
+    t.pass('callback fired')
+    t.end()
+  })
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -292,3 +292,48 @@ tape('Service.announce() (public entry) resets delay back to 1 s', function (t) 
   s._destroyed = true
   t.end()
 })
+
+// === 87068e8 — Service: don't resurrect a torn-down service in announce callback ===
+
+tape('onAnnounceComplete bails out when service was deactivated mid-announce', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  s._activated = true
+  s.packet = s._records()
+
+  const realSetTimeout = global.setTimeout
+  let scheduledNext = false
+  global.setTimeout = function () {
+    scheduledNext = true
+    return { unref: function () { return this } }
+  }
+
+  let upFired = false
+  s.on('up', function () { upFired = true })
+  s.on('service-announce-request', function () {})
+
+  s.announce()
+  s._activated = false // user calls stop() between announce() and the respond callback
+
+  s.onAnnounceComplete() // mdns invokes the announce-complete callback
+
+  global.setTimeout = realSetTimeout
+
+  t.equal(s._activated, false, 'remained inactive — not resurrected')
+  t.equal(s.published, false, 'not marked published')
+  t.equal(upFired, false, 'no spurious up event')
+  t.equal(scheduledNext, false, 'no follow-up re-announce scheduled')
+  t.end()
+})
+
+tape('onAnnounceComplete bails out for destroyed services', function (t) {
+  const s = new Service({ name: 'Foo', type: 'http', port: 3000 })
+  s._activated = true
+  s.packet = s._records()
+  s._destroyed = true
+
+  s.on('service-announce-request', function () {})
+  s.onAnnounceComplete()
+
+  t.equal(s.published, false, 'destroyed service not marked published')
+  t.end()
+})

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,66 @@
+'use strict'
+
+const dgram = require('dgram')
+const tape = require('tape')
+const Bonjour = require('../')
+const Service = require('../lib/Service.js')
+const Prober = require('../lib/Prober.js')
+
+const port = function (cb) {
+  const s = dgram.createSocket('udp4')
+  s.bind(0, function () {
+    const p = s.address().port
+    s.on('close', function () { cb(p) })
+    s.close()
+  })
+}
+
+// === e141abf — Server: continue past unanswered questions in multi-question queries ===
+
+tape('Server still answers later questions when an earlier one has no records', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+    server.register({ name: 'Hit._tcp.local', type: 'PTR', ttl: 120, data: 'instance._tcp.local' })
+
+    const responses = []
+    server.mdns.respond = function (pkt) { responses.push(pkt) }
+
+    server._respondToQuery({
+      questions: [
+        { name: 'Miss._tcp.local', type: 'PTR' },
+        { name: 'Hit._tcp.local', type: 'PTR' }
+      ]
+    })
+
+    t.equal(responses.length, 1, 'matched question still got a response')
+    t.equal(responses[0].answers[0].name, 'Hit._tcp.local')
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Server answers each question independently in multi-question packets', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+    server.register([
+      { name: 'A._tcp.local', type: 'PTR', ttl: 120, data: 'a' },
+      { name: 'B._tcp.local', type: 'PTR', ttl: 120, data: 'b' }
+    ])
+
+    const responses = []
+    server.mdns.respond = function (pkt) { responses.push(pkt) }
+
+    server._respondToQuery({
+      questions: [
+        { name: 'A._tcp.local', type: 'PTR' },
+        { name: 'B._tcp.local', type: 'PTR' }
+      ]
+    })
+
+    t.equal(responses.length, 2, 'one response per matched question')
+    t.equal(responses[0].answers[0].name, 'A._tcp.local')
+    t.equal(responses[1].answers[0].name, 'B._tcp.local')
+    bonjour.destroy(function () { t.end() })
+  })
+})


### PR DESCRIPTION
- fix(types): align `index.d.ts` with runtime
- chore: dependency updates
- fix(server): continue past unanswered questions in multi-question queries
- fix(browser): handle null opts in constructor
- fix(service): make stop() callback truly optional
- fix(server): compare names case-insensitively when unregistering records
- fix(browser): compare wildcard PTR name case-insensitively
- fix(browser): dedup wildcard PTR queries by service type, not parent name
- fix(prober): unref the initial probe-jitter timer
- fix(service): restore exponential re-announce backoff
- fix(service): don't resurrect torn-down services in announce callback
- fix(browser): suppress no-op 'update' events when nothing changed
- fix: broadcast goodbye records during Bonjour.destroy()
- fix(server): warn instead of crash when mdns respond fails
- fix(service): include meta-enumeration PTR in goodbye records
- fix: surface mdns errors via Bonjour 'error' event
- chore(ci): bump release workflow action versions