### PR TITLE
v3.10.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `bonjour-hap` will be documented in this file. This project tries to adhere to [Semantic Versioning](http://semver.org/).
 
+## v3.10.5 (Pending Release)
+
+### Changes
+
+- fix(server): stop one service unpublishing from withdrawing another's records
+
 ## v3.10.4 (2026-07-08)
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 ### Changes
 
 - fix(server): stop one service unpublishing from withdrawing another's records
+- fix(browser): drop the cached fqdn key that was actually inserted
 
 ## v3.10.4 (2026-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 
 - fix(server): stop one service unpublishing from withdrawing another's records
 - fix(browser): drop the cached fqdn key that was actually inserted
+- fix(prober): detach the response listener when the service stops first
 
 ## v3.10.4 (2026-07-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to `bonjour-hap` will be documented in this file. This proje
 - fix(server): stop one service unpublishing from withdrawing another's records
 - fix(browser): drop the cached fqdn key that was actually inserted
 - fix(prober): detach the response listener when the service stops first
+- chore(deps): dependency updates
 
 ## v3.10.4 (2026-07-08)
 

--- a/lib/Browser.js
+++ b/lib/Browser.js
@@ -149,7 +149,12 @@ Browser.prototype._removeService = function (fqdn) {
   })
   if (!service) return
   this.services.splice(index, 1)
-  delete this._serviceMap[fqdn]
+  // Delete the key that was actually inserted. The map is keyed by the fqdn as it was
+  // announced, but the lookup above is case-insensitive, so a goodbye with different
+  // casing removed the service from the list while leaving its map key behind. The
+  // service then looked cached forever: a later re-announcement took the update path,
+  // found nothing in the list, and returned - so 'up' never fired again.
+  delete this._serviceMap[service.fqdn]
   this.emit('down', service)
 }
 

--- a/lib/Prober.js
+++ b/lib/Prober.js
@@ -35,7 +35,14 @@ Prober.prototype = {
 
   try: function () {
     // abort if the service have or is being stopped in the meantime
-    if (!this.service._activated || this.service._destroyed) return
+    if (!this.service._activated || this.service._destroyed) {
+      // start() attached a 'response' listener before the probe jitter elapsed, so
+      // returning here without detaching leaked it for the life of the process - and
+      // Server sets maxListeners to 0, so nothing warned about the build-up.
+      this.mdns.removeListener('response', this.bound)
+      clearTimeout(this.timer)
+      return
+    }
 
     this.mdns.query(this.service.fqdn, 'ANY', function () {
       // This function will optionally be called with an error object. We'll

--- a/lib/Registry.js
+++ b/lib/Registry.js
@@ -2,6 +2,7 @@
 
 const Service = require('./Service.js')
 const Prober = require('./Prober.js')
+const helpers = require('./helpers.js')
 
 const Registry = function (server) {
   this._server = server
@@ -60,9 +61,28 @@ Registry.prototype = {
 
     if (records.length === 0) { return cb && cb() }
 
-    this._server.unregister(records)
+    // Every service on the host contributes the SAME A/AAAA records, and the
+    // registry deduplicates them, so there is only ever one copy. Removing this
+    // service's copy would therefore take the address records away from every
+    // sibling still published - and the goodbye below would tell the network
+    // those addresses are dead while they are still in use. Matching on rdata
+    // does not help here: the records are identical, which is the whole problem.
+    // So keep anything a service that is staying up still owns.
+    const goingDown = new Set(services)
+    const stillOwned = this._services
+      .filter(service => !goingDown.has(service) && service._activated)
+      .map(service => service._records())
+      .flat()
 
-    this._server.mdns.respond(records, this._onTearDownComplete.bind(this, services, cb))
+    const removable = records.filter(record => !stillOwned.some(helpers.isSameRecord(record)))
+
+    // Nothing left to withdraw, but the services are still down: mark them so
+    // and fire the callback, exactly as a completed respond() would have.
+    if (removable.length === 0) { return this._onTearDownComplete(services, cb) }
+
+    this._server.unregister(removable)
+
+    this._server.mdns.respond(removable, this._onTearDownComplete.bind(this, services, cb))
   },
 
   _onTearDownComplete: function (services, cb) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -94,9 +94,13 @@ Object.assign(Server.prototype, {
 
       if (!(type in this.registry)) { continue }
 
-      this.registry[type] = this.registry[type].filter(r => {
-        return !dnsEqual(r.name, record.name)
-      })
+      // Match the rdata too, not just the name. Records legitimately share a name:
+      // every service of the same type shares the type PTR name, and every service on
+      // the host shares the A/AAAA name. Removing by name alone meant unpublishing one
+      // service also dropped the other services' records, and they stayed missing
+      // until their own next re-announce - which backs off up to an hour.
+      const isSameRecord = helpers.isSameRecord(record)
+      this.registry[type] = this.registry[type].filter(r => !isSameRecord(r))
     }
   },
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,12 +1,29 @@
 'use strict'
 
 const deepEqual = require('fast-deep-equal')
+const dnsEqual = require('./utils/dnsEqual')
 
 module.exports = {
+  /**
+     * Whether b is already in the registry as a. Delegates to isSameRecord so that
+     * "already registered" and "the record to remove" cannot disagree: comparing
+     * names exactly here while unregister compared them case-insensitively meant
+     * Foo.local and foo.local registered as two entries but unregistered as one.
+     */
   isDuplicateRecord: function (a) {
+    return module.exports.isSameRecord(a)
+  },
+  /**
+     * Whether b is the same record as a: same type, same name (compared the way DNS
+     * compares names, case-insensitively) and the same rdata.
+     *
+     * Names alone do not identify a record. Every service of the same type shares the
+     * type PTR name, and every service on the host shares the A/AAAA name.
+     */
+  isSameRecord: function (a) {
     return function (b) {
       return a.type === b.type &&
-                a.name === b.name &&
+                dnsEqual(a.name, b.name) &&
                 deepEqual(a.data, b.data)
     }
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -95,14 +95,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -225,13 +225,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -256,18 +256,18 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -275,9 +275,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -289,9 +289,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
-      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.10.1.tgz",
+      "integrity": "sha512-cuadcxVFE8sDK6iWJbs8Sn0av2Nrh2QSGQhVlBW9AaAHqHwjWsZHT8LJ4hFGPh7ASBV2deFdM7H/DPjulmh8rg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -356,9 +356,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -436,9 +436,9 @@
       "license": "MIT"
     },
     "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -662,16 +662,16 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1005,9 +1005,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.42",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.42.tgz",
-      "integrity": "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q==",
+      "version": "2.11.14",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
+      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1018,22 +1018,22 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.5",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.5.tgz",
-      "integrity": "sha512-Cu2E6QejHWzuDMTkuwgpABFgDfZrXLQq5V13YOACZx4mFAG4IwGTbTfHPMr4WtxlHoXSM8FIuRwYYCz5XiabaQ==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "dev": true,
       "funding": [
         {
@@ -1051,11 +1051,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.42",
-        "caniuse-lite": "^1.0.30001800",
-        "electron-to-chromium": "^1.5.387",
-        "node-releases": "^2.0.50",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -1161,9 +1161,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001803",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001803.tgz",
-      "integrity": "sha512-g/uHREV2ZpK9qMalCsWaxmA6ol+DX8GYhuf3T40RKoP+oL7vhRJh8LNt73PCjpnR6l14FzfPrB5Yux4PKm2meg==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "dev": true,
       "funding": [
         {
@@ -1506,9 +1506,9 @@
       "license": "MIT"
     },
     "node_modules/dotignore/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1545,9 +1545,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.389",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.389.tgz",
-      "integrity": "sha512-cEto7aeOqBfU1D+c5py5pE+ooscKE75JifxLBdFUZsqAxRS6y7kebtxAZvICszSl05gPjYHDTjY+lXpyGvpJbg==",
+      "version": "1.5.407",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.407.tgz",
+      "integrity": "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -1698,9 +1698,9 @@
       }
     },
     "node_modules/es-iterator-helpers": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.3.3.tgz",
-      "integrity": "sha512-0PuBxFi+4uPanB97iDxCLWuHeYud2FALrw5HFZGtAF38UpJDbDC8frwp2cnDyae692CQ0dou60UwWfhgsa4U/g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/es-iterator-helpers/-/es-iterator-helpers-1.4.0.tgz",
+      "integrity": "sha512-c/A0P0oxkACDc+cKWw8evLXK83oBKgn0qPOqCYT4x9uolpCIJAcYvJC9QYKNDRPsTeGyCrQ326jrvgZWdCdK5Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2068,9 +2068,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2158,9 +2158,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-n/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2260,9 +2260,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2380,9 +2380,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2408,9 +2408,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -2667,9 +2667,9 @@
       "license": "MIT"
     },
     "node_modules/flat-cache/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2730,9 +2730,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
-      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.4.tgz",
+      "integrity": "sha512-5+ybhBZANEJxaH3X5evAFatUxLfEHSr7n6kYJ+1Qd0mUqr4eu9gIf6GDbWHf8RJijHrjjO8G+la14SlL2SeS1Q==",
       "dev": true,
       "license": "ISC"
     },
@@ -3924,9 +3924,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4155,13 +4155,13 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.5"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -4289,9 +4289,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -4509,13 +4509,14 @@
       }
     },
     "node_modules/own-keys": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.1.tgz",
-      "integrity": "sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/own-keys/-/own-keys-1.0.2.tgz",
+      "integrity": "sha512-19YVAg7T+WTrxggPukVq7DjTv6+PJ867TmhCvBsYwmbFCsZd344rq2Ld1p0wo8f8Qrrhgp82c6FJRqdXWtSEhg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "get-intrinsic": "^1.2.6",
+        "call-bound": "^1.0.4",
+        "get-intrinsic": "^1.3.0",
         "object-keys": "^1.1.1",
         "safe-push-apply": "^1.0.0"
       },
@@ -5631,9 +5632,9 @@
       "license": "MIT"
     },
     "node_modules/tape/node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5871,9 +5872,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "dev": true,
       "funding": [
         {

--- a/test/regression.js
+++ b/test/regression.js
@@ -160,6 +160,27 @@ tape('Server.unregister keeps other services sharing a record name', function (t
   })
 })
 
+tape('Prober detaches its response listener when the service stops first', function (t) {
+  const Prober = require('../lib/Prober.js')
+  const EventEmitter = require('events').EventEmitter
+
+  const mdns = new EventEmitter()
+  mdns.query = function () { t.fail('should not have queried for a stopped service') }
+
+  // stopped during the 0-250ms probe jitter, which is the window start() opens
+  const service = { fqdn: 'Gone._hap._tcp.local', _activated: false, _destroyed: false }
+  const prober = new Prober(mdns, service, function () {
+    t.fail('the callback must not fire for a stopped service')
+  })
+
+  prober.start()
+  t.equal(mdns.listenerCount('response'), 1, 'precondition: listener attached')
+
+  prober.try()
+  t.equal(mdns.listenerCount('response'), 0, 'listener detached rather than leaked')
+  t.end()
+})
+
 tape('Browser re-adds a service after a goodbye with different casing', function (t) {
   const Browser = require('../lib/Browser.js')
   const browser = Object.create(Browser.prototype)

--- a/test/regression.js
+++ b/test/regression.js
@@ -5,6 +5,7 @@ const tape = require('tape')
 const Bonjour = require('../')
 const Service = require('../lib/Service.js')
 const Prober = require('../lib/Prober.js')
+const helpers = require('../lib/helpers.js')
 
 const port = function (cb) {
   const s = dgram.createSocket('udp4')
@@ -126,6 +127,35 @@ tape('Server.unregister leaves non-matching records intact', function (t) {
     server.unregister({ name: 'a._TCP.LOCAL', type: 'PTR', ttl: 120, data: 'a' })
     t.equal(server.registry.PTR.length, 1, 'one record left')
     t.equal(server.registry.PTR[0].name, 'B._tcp.local', 'B was not removed')
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('Server.unregister keeps other services sharing a record name', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+
+    // Two services of the same type share the type PTR name, and every service on
+    // the host shares the A record name. Removing by name alone took the sibling
+    // records down too, so unpublishing one bridge made the other undiscoverable
+    // until its own re-announce - a back-off that reaches an hour.
+    server.register([
+      { name: '_hap._tcp.local', type: 'PTR', ttl: 4500, data: 'Bridge A._hap._tcp.local' },
+      { name: '_hap._tcp.local', type: 'PTR', ttl: 4500, data: 'Bridge B._hap._tcp.local' },
+      { name: 'myhost.local', type: 'A', ttl: 120, data: '192.168.1.10' },
+      { name: 'myhost.local', type: 'A', ttl: 120, data: '10.0.0.5' }
+    ])
+
+    // goodbye records for Bridge A only, with ttl zeroed the way _tearDown does it
+    server.unregister([
+      { name: '_hap._tcp.local', type: 'PTR', ttl: 0, data: 'Bridge A._hap._tcp.local' },
+      { name: 'MYHOST.LOCAL', type: 'A', ttl: 0, data: '192.168.1.10' }
+    ])
+
+    t.deepEqual(server.registry.PTR.map(r => r.data), ['Bridge B._hap._tcp.local'], 'Bridge B PTR survived')
+    t.deepEqual(server.registry.A.map(r => r.data), ['10.0.0.5'], 'the other address record survived')
+
     bonjour.destroy(function () { t.end() })
   })
 })
@@ -563,5 +593,91 @@ tape('Bonjour forwards underlying mdns socket errors via the error event', funct
       t.equal(received.message, 'socket boom')
       bonjour.destroy(function () { t.end() })
     })
+  })
+})
+
+// === Registry._tearDown: shared A/AAAA records survive a sibling unpublishing ===
+
+tape('unpublishing one service keeps the address records its siblings share', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+
+    // Two services on ONE host, so both contribute identical A records. The
+    // registry stores a single copy, which is exactly why removing "this
+    // service's" copy used to take the other service's addresses with it.
+    const one = bonjour.publish({ name: 'One', type: 'test', port: 3000, probe: false })
+    const two = bonjour.publish({ name: 'Two', type: 'test', port: 3001, probe: false })
+
+    setTimeout(function () {
+      const addressesFor = function (service) {
+        return service._records().filter(function (r) { return r.type === 'A' || r.type === 'AAAA' })
+      }
+      const shared = addressesFor(two)
+      t.ok(shared.length > 0, 'precondition: the surviving service has address records')
+
+      const goodbyes = []
+      const respond = server.mdns.respond.bind(server.mdns)
+      server.mdns.respond = function (packet, cb) {
+        const records = Array.isArray(packet) ? packet : (packet.answers || [])
+        records.forEach(function (r) { if (r.ttl === 0) goodbyes.push(r) })
+        return respond(packet, cb)
+      }
+
+      one.stop(function () {
+        const survives = function (record) {
+          return (server.registry[record.type] || []).some(helpers.isSameRecord(record))
+        }
+
+        t.ok(shared.every(survives), 'the surviving service still has its address records registered')
+        t.notOk(
+          goodbyes.some(function (g) { return shared.some(helpers.isSameRecord(g)) }),
+          'no goodbye was sent for an address the surviving service still uses'
+        )
+
+        // The service that stopped must still have withdrawn its own unique records
+        t.ok(goodbyes.some(function (g) { return g.type === 'SRV' }), 'its own SRV was withdrawn')
+
+        server.mdns.respond = respond
+        bonjour.destroy(function () { t.end() })
+      })
+    }, 100)
+  })
+})
+
+// === Server.register / unregister: one definition of "the same record" ===
+
+tape('register treats names case-insensitively, as unregister does', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+
+    // DNS compares names case-insensitively, so these are one record, not two.
+    // Registering exactly but unregistering case-insensitively is how the two
+    // sides drift apart: two entries go in and a single unregister takes both.
+    server.register({ name: 'Foo.local', type: 'A', ttl: 120, data: '1.2.3.4' })
+    server.register({ name: 'foo.LOCAL', type: 'A', ttl: 120, data: '1.2.3.4' })
+
+    t.equal(server.registry.A.length, 1, 'stored once, not twice')
+
+    server.unregister({ name: 'FOO.local', type: 'A', ttl: 120, data: '1.2.3.4' })
+    t.equal(server.registry.A.length, 0, 'and removed by any casing')
+
+    bonjour.destroy(function () { t.end() })
+  })
+})
+
+tape('register still keeps records that differ only in their data', function (t) {
+  port(function (p) {
+    const bonjour = Bonjour({ ip: '127.0.0.1', port: p, multicast: false })
+    const server = bonjour._server
+
+    // Same name, different address: a dual-homed host, and both are real records
+    server.register({ name: 'foo.local', type: 'A', ttl: 120, data: '1.2.3.4' })
+    server.register({ name: 'foo.local', type: 'A', ttl: 120, data: '5.6.7.8' })
+
+    t.equal(server.registry.A.length, 2, 'both kept')
+
+    bonjour.destroy(function () { t.end() })
   })
 })

--- a/test/regression.js
+++ b/test/regression.js
@@ -160,6 +160,34 @@ tape('Server.unregister keeps other services sharing a record name', function (t
   })
 })
 
+tape('Browser re-adds a service after a goodbye with different casing', function (t) {
+  const Browser = require('../lib/Browser.js')
+  const browser = Object.create(Browser.prototype)
+  require('events').EventEmitter.call(browser)
+  browser.services = []
+  browser._serviceMap = {}
+
+  browser._addService({ fqdn: 'Bridge A._hap._tcp.local' })
+  browser._removeService('bridge a._HAP._tcp.LOCAL')
+
+  t.equal(browser.services.length, 0, 'the goodbye removed it from the list')
+  t.deepEqual(Object.keys(browser._serviceMap), [], 'and left no stale cache key behind')
+
+  // the service comes back - it must be treated as new, not as a cached update
+  let ups = 0
+  browser.on('up', function () { ups++ })
+  const returning = { fqdn: 'Bridge A._hap._tcp.local' }
+  if (browser._serviceMap[returning.fqdn]) {
+    browser._updateService(returning)
+  } else {
+    browser._addService(returning)
+  }
+
+  t.equal(ups, 1, "'up' fired again for the returning service")
+  t.equal(browser.services.length, 1, 'and it is back in the list')
+  t.end()
+})
+
 // === 8d8d9aa — Browser: wildcard meta-PTR name comparison is case-insensitive ===
 
 tape('Browser wildcard accepts a meta-enumeration PTR with mixed-case name', function (t) {


### PR DESCRIPTION
### Changes

- fix(server): stop one service unpublishing from withdrawing another's records
- fix(browser): drop the cached fqdn key that was actually inserted
- fix(prober): detach the response listener when the service stops first
- chore(deps): dependency updates